### PR TITLE
Revert to hardcoded https

### DIFF
--- a/site/launch.php
+++ b/site/launch.php
@@ -25,7 +25,7 @@ $path = dirname($_SERVER['REQUEST_URI']);
 if($path !== '/') {
    $path .= '/';
 }
-$location = 'http://' . $_SERVER['HTTP_HOST'] . $path . $location; # TODO: Can we let the https rewrite handle this?
+$location = 'https://' . $_SERVER['HTTP_HOST'] . $path . $location;
 header("Location: {$location}");
 ?>
 <html>


### PR DESCRIPTION
It should be safe to switch this back. I was testing with http at some
point and it made sense, but now it will probably cause issues in
ceratain cases.