### PR TITLE
make last week's forecast always stitch to the week it was forecasted for

### DIFF
--- a/site/FAQ.php
+++ b/site/FAQ.php
@@ -22,7 +22,7 @@ require_once('common/navigation.php');
     
     <p>
       <font size="5">
-	1. What data I should be basing a forecast on, is
+	1. What data should I be basing a forecast on, is
         it the situation of people in my current state?
       </font>
     </p>


### PR DESCRIPTION
When the most recent CDC data is for 202012, your first forecasted point is for 202013, and the "current forecast" curve stitches to the CDC point at 202012. 

The following week, the "last week's forecast" curve should stitch to the CDC point for 202012. 

It currently stitches to the most recent available CDC point, regardless of whether that is 202012 (for Monday afternoon-Friday morning) or 202013 (for Friday afternoon-Monday morning).

The "current forecast" curve should always stitch to the most recent available CDC data.